### PR TITLE
FSSK Issue #5: Delete todo bug

### DIFF
--- a/client/src/module/common/component/form-input-component.tsx
+++ b/client/src/module/common/component/form-input-component.tsx
@@ -15,6 +15,7 @@ interface IFormInputProps {
 	errorClass?: string;
 	readonly?: boolean;
 	disabled?: boolean;
+	autoFocus?: boolean;
 	size?: number;
 	maxLength?: number;
 }
@@ -37,6 +38,7 @@ const formInput: React.StatelessComponent<IFormInputProps> = ({
 	errorClass,
 	readonly,
 	disabled,
+	autoFocus,
 	size,
 	maxLength,
 	}) => {
@@ -61,6 +63,7 @@ const formInput: React.StatelessComponent<IFormInputProps> = ({
 				readOnly={readonly}
 				disabled={disabled}
 				size={size}
+				autoFocus={autoFocus}
 				maxLength={maxLength}
 			/>
 
@@ -79,6 +82,7 @@ formInput.defaultProps = {
 	type: "text",
 	error: "",
 	placeholder: "",
+	autoFocus: false,
 };
 
 export default formInput;

--- a/client/src/module/todo/component/todo-item-component.tsx
+++ b/client/src/module/todo/component/todo-item-component.tsx
@@ -54,6 +54,7 @@ export default class TodoItemComponent extends React.Component<ITodoItemComponen
 						inputClass="form-control"
 						type="text"
 						name="title"
+						autoFocus
 						placeholder="What do you need to do?"
 						value={this.props.todo.title}
 						onChange={this.props.updateField(this.props.todoIndex)}
@@ -80,7 +81,7 @@ export default class TodoItemComponent extends React.Component<ITodoItemComponen
 	private renderTodoItem() {
 		return (
 			<div className="form-row">
-				<div className="col-sm-10">
+				<div className="col-10">
 					<div className="form-check">
 						<input
 							className="form-check-input"

--- a/client/src/module/todo/component/todo-item-component.tsx
+++ b/client/src/module/todo/component/todo-item-component.tsx
@@ -8,7 +8,7 @@ interface ITodoItemComponentProps {
 	todo: TodoModel;
 	todoIndex: number;
 	updateField: (todoIndex: number) => (name: string, value: string) => void;
-	cancelAdd: () => void;
+	cancelAdd: (todo: TodoModel) => void;
 	cancelUpdate: (todoIndex: number, val: string) => void;
 	saveTodo: (todo: TodoModel) => void;
 	updateTodo: (todo: TodoModel, newProps: ITodoModelProps) => void;
@@ -32,64 +32,84 @@ export default class TodoItemComponent extends React.Component<ITodoItemComponen
 	}
 
 	public render() {
-		const todoitem = this.renderTodoItem();
+		const todoElement = this.state.editable ? this.renderTodoForm() : this.renderTodoItem();
 		return (
 			<li className="list-group-item list-group-flush">
-				<div className="form-check">
-					<input
-						className="form-check-input"
-						type="checkbox"
-						id={this.props.todo.id}
-						checked={!!this.props.todo.completed}
-						onChange={this.toggleCompleted}
-					/>
-					{todoitem}
-				</div>
+				{todoElement}
 			</li>
 		);
 	}
 
-	private renderTodoItem() {
-		if (this.state.editable) {
-			return (
-				<div className="form-inline">
-				<FormInput
+	@autobind
+	private submitTodoForm(event: any) {
+		event.preventDefault();
+		this.updateTodo();
+	}
+
+	private renderTodoForm() {
+		return (
+			<form className="form-row" onSubmit={this.submitTodoForm}>
+				<div className="col-10">
+					<FormInput
 						inputClass="form-control"
 						type="text"
 						name="title"
 						placeholder="What do you need to do?"
 						value={this.props.todo.title}
 						onChange={this.props.updateField(this.props.todoIndex)}
-						size={40}
-				/>
-				<button
-					className="btn btn-primary btn-sm"
-					onClick={this.updateTodo}
-				>Save
-				</button>
-				<button
-					className="btn btn-outline-secondary btn-sm"
-					onClick={this.cancelUpdateTodo}
-				>Cancel
-				</button>
+					/>
 				</div>
-			);
-		} else {
-			return (
-				<div className="form-inline">
-					<label className="form-check-label"  htmlFor={this.props.todo.id}>
-						{!this.state.editable && <span>{this.state.title} (updated {this.props.todo.timeSinceUpdated()})</span>}
-					</label>
-					<button className="btn btn-outline-primary btn-sm" onClick={this.enableEditing}>Update</button>
+				<div className="col-1">
+					<button
+						className="btn btn-primary btn-sm"
+						type="submit"
+					>Save
+					</button>
+				</div>
+				<div className="col-1">
+					<button
+						className="btn btn-outline-secondary btn-sm"
+						onClick={this.cancelUpdateTodo}
+					>Cancel
+					</button>
+				</div>
+			</form>
+		);
+	}
+
+	private renderTodoItem() {
+		return (
+			<div className="form-row">
+				<div className="col-sm-10">
+					<div className="form-check">
+						<input
+							className="form-check-input"
+							type="checkbox"
+							id={this.props.todo.id}
+							checked={!!this.props.todo.completed}
+							onChange={this.toggleCompleted}
+						/>
+						<label className="form-check-label"  htmlFor={this.props.todo.id}>
+							{!this.state.editable && <span>{this.state.title} <em>(updated {this.props.todo.timeSinceUpdated()})</em></span>}
+						</label>
+					</div>
+				</div>
+				<div className="col-1">
+					<button
+						className="btn btn-outline-primary btn-sm"
+						onClick={this.enableEditing}
+					>Update
+					</button>
+				</div>
+				<div className="col-1">
 					<button
 						className="btn btn-link btn-sm"
 						onClick={this.deleteTodo}
 					>Delete
 					</button>
 				</div>
-			);
-
-		}
+			</div>
+		);
 	}
 
 	@autobind
@@ -123,7 +143,7 @@ export default class TodoItemComponent extends React.Component<ITodoItemComponen
 	@autobind
 	private cancelUpdateTodo() {
 		if (!this.state.title) {
-			this.props.cancelAdd();
+			this.props.cancelAdd(this.props.todo);
 		} else {
 			this.props.cancelUpdate(this.props.todoIndex, this.state.title);
 			this.setState({ editable: false });

--- a/client/src/module/todo/container/todo-container.tsx
+++ b/client/src/module/todo/container/todo-container.tsx
@@ -38,9 +38,17 @@ export default class TodoContainer extends React.Component<any> {
 					<div className="card" style={cardStyle}>
 						<h2 className="card-header">To-Do List</h2>
 						<ul className="list-group list-group-flush">
-							{TodoStore.todos.map((todo: TodoModel, i: number) =>
-								<TodoItemComponent key={i} todo={todo} todoIndex={i} {...eventHandlers}/>,
-							)}
+							{TodoStore.todos.map((todo: TodoModel, i: number) => {
+								const itemComponentKey = todo && todo.id ? `id-${todo.id}` : `new-${i}`;
+								return (
+									<TodoItemComponent
+										key={`ItemComponent-${itemComponentKey}`}
+										todo={todo}
+										todoIndex={i}
+										{...eventHandlers}
+									/>
+								);
+							})}
 							<li className="list-group-item"><button className="btn btn-success" onClick={this.addTodo}>+</button></li>
 						</ul>
 					</div>
@@ -55,7 +63,7 @@ export default class TodoContainer extends React.Component<any> {
 	}
 
 	private saveTodo(todo: TodoModel) {
-		TodoStore.saveAndAddTodo(todo);
+		TodoStore.saveTodo(todo);
 	}
 
 	private updateTodo(todo: TodoModel, newProps: ITodoModelProps) {

--- a/client/src/module/todo/model/todo-model.ts
+++ b/client/src/module/todo/model/todo-model.ts
@@ -6,8 +6,8 @@ export interface ITodoModelProps {
 	title?: string;
 	order?: number;
 	completed?: boolean;
-	createdAt?: string;
-	updatedAt?: string;
+	created_at?: string;
+	updated_at?: string;
 	user_id?: string;
 }
 
@@ -52,8 +52,8 @@ export default class TodoModel {
 			if (props.order) { this.order = props.order; }
 			if (props.completed !== undefined) { this.completed = props.completed; }
 			if (props.user_id !== undefined) { this.user_id = props.user_id; }
-			if (props.createdAt) { this.createdAt = props.createdAt; }
-			if (props.updatedAt) { this.updatedAt = props.updatedAt; }
+			if (props.created_at) { this.createdAt = props.created_at; }
+			if (props.updated_at) { this.updatedAt = props.updated_at; }
 		});
 	}
 

--- a/client/src/module/todo/store/todo-store.spec.ts
+++ b/client/src/module/todo/store/todo-store.spec.ts
@@ -5,6 +5,47 @@ import { TodoStore } from "./todo-store";
 
 describe("TodoStore", () => {
 
+	describe("saveTodo", () => {
+		const testProps = { id: undefined, title: "Howdy" };
+		const testModel = new TodoModel(testProps);
+
+		afterEach(() => {
+			fetchMock.restore();
+		});
+
+		it ("should save todo with given props", () => {
+			// Mock our save to return a saved model with a new id
+			const responsePostBody = {id: "1", title: "So Long"}
+			fetchMock.post("*", {
+				status: 201,
+				headers: {"Content-Type":  "application/json"},
+				body: responsePostBody,
+			});
+
+			// Create new store and add our model to it
+			const store = new TodoStore();
+			store.addTodo(testModel);
+
+			// Save the todo
+			return store.saveTodo(testModel).then((savedTodo) => {
+				// We should get a todo that was saved
+				expect(savedTodo).toBeDefined();
+				if(savedTodo) {
+					// Expect the todo we saved to be equal the one we posted
+					expect(savedTodo.id).toEqual(responsePostBody.id);
+					expect(savedTodo.title).toEqual(responsePostBody.title);
+
+					// The test model should be updated with what was returned from saving
+					expect(testModel.title).toEqual(savedTodo.title);
+					expect(testModel.id).toEqual(savedTodo.id);
+
+					// Should have one todo in store
+					expect(store.todos.length).toEqual(1);
+				}
+			});
+		});
+	})
+
 	describe("saveAndAddTodo", () => {
 		const testProps = { id: "1", title: "Hello" };
 		const testModel = new TodoModel(testProps);
@@ -14,7 +55,6 @@ describe("TodoStore", () => {
 		});
 
 		it("should create new todo with given props", () => {
-
 			fetchMock.post("*", {
 				status: 201,
 				headers: {"Content-Type":  "application/json"},
@@ -27,6 +67,9 @@ describe("TodoStore", () => {
 				if (addedTodo) {
 					expect(addedTodo.title).toEqual(testModel.title);
 				}
+
+				// Should have one todo in store
+				expect(store.todos.length).toEqual(1);
 			});
 		});
 

--- a/client/src/module/todo/store/todo-store.spec.ts
+++ b/client/src/module/todo/store/todo-store.spec.ts
@@ -15,7 +15,7 @@ describe("TodoStore", () => {
 
 		it ("should save todo with given props", () => {
 			// Mock our save to return a saved model with a new id
-			const responsePostBody = {id: "1", title: "So Long"}
+			const responsePostBody = {id: "1", title: "So Long"};
 			fetchMock.post("*", {
 				status: 201,
 				headers: {"Content-Type":  "application/json"},
@@ -30,7 +30,7 @@ describe("TodoStore", () => {
 			return store.saveTodo(testModel).then((savedTodo) => {
 				// We should get a todo that was saved
 				expect(savedTodo).toBeDefined();
-				if(savedTodo) {
+				if (savedTodo) {
 					// Expect the todo we saved to be equal the one we posted
 					expect(savedTodo.id).toEqual(responsePostBody.id);
 					expect(savedTodo.title).toEqual(responsePostBody.title);
@@ -44,7 +44,7 @@ describe("TodoStore", () => {
 				}
 			});
 		});
-	})
+	});
 
 	describe("saveAndAddTodo", () => {
 		const testProps = { id: "1", title: "Hello" };

--- a/client/src/module/todo/store/todo-store.ts
+++ b/client/src/module/todo/store/todo-store.ts
@@ -25,8 +25,8 @@ export class TodoStore {
 		this.todos[index].title = val;
 	}
 
-	@action.bound public cancelAdd() {
-		this.todos.pop();
+	@action.bound public cancelAdd(todo: TodoModel) {
+		this.deleteTodo(todo);
 	}
 
 	@action public addTodo(todo: TodoModel): TodoModel {
@@ -54,6 +54,19 @@ export class TodoStore {
 		}
 	}
 
+	@action public async saveTodo(todo: TodoModel): Promise<TodoModel | undefined> {
+		try {
+			const todoData: any = await fetchUtil("/api/todos", {
+				body: todo.getPostProperties(),
+				method: "POST",
+			});
+			todo.setProperties(todoData);
+		} catch (error) {
+			this.handleError(error);
+		}
+		return todo;
+	}
+
 	@action public async saveAndAddTodo(todo: TodoModel): Promise<TodoModel | undefined> {
 		let addedTodo: TodoModel | undefined;
 		try {
@@ -61,7 +74,7 @@ export class TodoStore {
 				body: todo.getPostProperties(),
 				method: "POST",
 			});
-			this.cancelAdd();
+			this.cancelAdd(todo);
 			addedTodo = this.addTodo(new TodoModel(todoData));
 		} catch (error) {
 			this.handleError(error);
@@ -94,8 +107,6 @@ export class TodoStore {
 		}
 		return todo;
 	}
-
-
 
 	@action private deleteTodo(todo: TodoModel): void {
 		let idx: number;

--- a/server/src/components/todos/index.ts
+++ b/server/src/components/todos/index.ts
@@ -30,8 +30,8 @@ export default class TodosController {
 			throw new Error("Invalid ID");
 		}
 		const collection = await new TodoModel()
-			.orderBy('order')
-			.orderBy('created_at')
+			.orderBy("order")
+			.orderBy("created_at")
 			.where({user_id: userId})
 			.fetchAll()
 			.catch(handleDatabaseErrors);

--- a/server/src/components/todos/index.ts
+++ b/server/src/components/todos/index.ts
@@ -30,6 +30,8 @@ export default class TodosController {
 			throw new Error("Invalid ID");
 		}
 		const collection = await new TodoModel()
+			.orderBy('order')
+			.orderBy('created_at')
 			.where({user_id: userId})
 			.fetchAll()
 			.catch(handleDatabaseErrors);


### PR DESCRIPTION
This is a fix for Issue https://github.com/EarthlingInteractive/fssk-node/issues/5

The bug was primarily fixed by having a more specific key for each todo-item-component.

Additionally, I needed to change the assumption that when saving a todo that the last one in the list is the one that was just modified by the form and needs to be removed (via a pop) before we can add a new one to the list. I noticed this when I added multiple empty todos - like 3 new ones, and edited the one in the middle and duplicate (yet fake) entries replaced the other forms.

 I also made some other changes:
- Rearranged todo-item-component to not display the checkbox if a todo is being edited. Clicking on it would cause an error because it didn't have an id to flag as complete yet.
- Fixed the todo-model to support loading the updated_at and created_at dates from the API properly. Now the todo listing shows the correct date when a todo was last updated.
- Added the ability to submit new todo by hitting enter.
- When adding a new todo the input field is automatically focused so users can immediately start typing.
- Used some bootstrap styling to make the todo row listing a little easier to read and use.

I noticed that there is another error involving the todo form input field, and a component changing uncontrolled input react error occurs. However, this requires a bigger functional change between the form and the way it interacts with stores that I believe is way outside of the scope of this current bugfix.
