### PR TITLE
Add an alias to the fssk-node-server that the client can use as a dev server proxy

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -13,6 +13,10 @@ services:
       volumes:
         - './client:/opt/src'
       working_dir: '/opt/src'
+      depends_on:
+        - fssk-node-server
+      links:
+      - 'fssk-node-server:fssk-server'
       networks:
         - app
   fssk-node-server:


### PR DESCRIPTION
Using an alias instead of a container name will enable multiple server backends (express, nest.js, etc.) to be compatible with the client repo and will avoid errors due to docker containers having the same name.

This needs to be merged along with the corresponding changes to the client repo: https://github.com/EarthlingInteractive/fssk-react-client/pull/3